### PR TITLE
Add wait InService state for SageMaker notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An AWS CDK project that automatically starts, stops, reboots and terminates reso
  * RDS Instances
  * RDS Clusters
  * ECS Services
+ * SageMaker Instances
 
 ## Supported Tags
 
@@ -15,6 +16,7 @@ An AWS CDK project that automatically starts, stops, reboots and terminates reso
 | autostate:timezone                  | The timezone to use when interpreting schedules. Defaults to UTC. Example: America/Denver                          |
 | autostate:start-schedule            | The schedule as a cron expression to start the resource. Example: 0 8 * * 1-5                                      |
 | autostate:stop-schedule             | The schedule as a cron expression to stop the resource. Example: 0 18 * * 1-5                                      |
+| autostate:terminate-schedule        | The schedule as a cron expression to terminate the resource. Example: 0 18 * * 1-5                                      |
 | autostate:reboot-schedule           | The schedule as a cron expression to reboot the instance. Example: 0 12 * * 1-5                                    |
 | autostate:max-runtime               | The number of minutes the resource may run before being stopped.                                                   |
 | autostate:max-lifetime              | The number of minutes the resource may exist before being terminated.                                              |
@@ -62,7 +64,7 @@ Start an instance every 30 minutes and shut it down 10 minutes after it starts o
 
 ## Caveats
 
- * RDS doesn't allow asterisks or commas in tag values so use hyphens and colons instead when defining cron expressions
+ * RDS and SageMaker doesn't allow asterisks or commas in tag values so use hyphens and colons instead when defining cron expressions
     Start an RDS cluster every 30 minutes and shut it down 15 minutes after it starts on weekdays.
     ```json
     {

--- a/cdk/lib/autostate-construct.ts
+++ b/cdk/lib/autostate-construct.ts
@@ -15,6 +15,7 @@ import {
   WaitTime,
   Map as SfnMap,
   DefinitionBody,
+  TaskInput,
 } from 'aws-cdk-lib/aws-stepfunctions';
 import {
   CallAwsService,
@@ -91,6 +92,76 @@ export class AutoState extends Construct {
       iamResources: ['*'],
       resultPath: '$.result',
     });
+
+    const setNotebookResource = new Pass(this, 'SetNotebookResource', {
+      resultPath: '$.resource',
+      parameters: {
+        'type': 'sagemaker-notebook',
+        'id.$':
+          '$.Execution.Input.detail.requestParameters.notebookInstanceName',
+      },
+    });
+
+    const describeNotebook = new CallAwsService(this, 'DescribeNotebook', {
+      service: 'sagemaker',
+      action: 'describeNotebookInstance',
+      parameters: {
+        NotebookInstanceName: JsonPath.stringAt('$.resource.id'),
+      },
+      iamAction: 'sagemaker:DescribeNotebookInstance',
+      iamResources: ['*'],
+      resultPath: '$.describe',
+    });
+
+    const waitNotebook = new Wait(this, 'WaitNotebookInService', {
+      time: WaitTime.duration(Duration.minutes(2)),
+    });
+
+    const buildInServiceEvent = new Pass(this, 'BuildNotebookInServiceEvent', {
+      parameters: {
+        'StateMachine.$': '$$.StateMachine',
+        'Execution': {
+          Input: {
+            'detail-type': 'AWS API Call via CloudTrail',
+            'source': 'aws.sagemaker',
+            'detail': {
+              requestParameters: {
+                'notebookInstanceName.$': '$.resource.id',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const notifyInService = new LambdaInvoke(this, 'NotifyInService', {
+      lambdaFunction: schedulerFunction,
+      payload: TaskInput.fromJsonPathAt('$'),
+      outputPath: '$.Payload',
+    });
+
+    const pollUntilInService = new Choice(this, 'NotebookInService?')
+      .when(
+        Condition.stringEquals(
+          '$.describe.NotebookInstanceStatus',
+          'InService',
+        ),
+        buildInServiceEvent.next(notifyInService),
+      )
+      .when(
+        Condition.or(
+          Condition.stringEquals(
+            '$.describe.NotebookInstanceStatus',
+            'Pending',
+          ),
+          Condition.stringEquals(
+            '$.describe.NotebookInstanceStatus',
+            'Updating',
+          ),
+        ),
+        waitNotebook.next(describeNotebook),
+      )
+      .otherwise(new Pass(this, 'NotebookNotInServiceSkip'));
 
     const startSageMakerInstance = new CallAwsService(
       this,
@@ -482,6 +553,21 @@ export class AutoState extends Construct {
       ),
       eventProcessor,
     );
+    eventRouter.when(
+      Condition.and(
+        Condition.stringEquals(
+          '$.Execution.Input.detail-type',
+          'AWS API Call via CloudTrail',
+        ),
+        Condition.stringEquals('$.Execution.Input.source', 'aws.sagemaker'),
+        Condition.stringEquals(
+          '$.Execution.Input.detail.eventName',
+          'StartNotebookInstance',
+        ),
+      ),
+      setNotebookResource.next(describeNotebook).next(pollUntilInService),
+    );
+
     eventRouter.when(
       Condition.and(
         Condition.stringEquals(

--- a/handlers/src/scheduler.mts
+++ b/handlers/src/scheduler.mts
@@ -835,13 +835,22 @@ export async function processStateAction(
     }
   }
   if (action.action === 'stop' || action.action === 'reboot') {
-    // When max-runtime is used we must check the previous start time to ensure we should be proceeding
-    if (resource.tags.maxRuntime && resource.state === 'running') {
-      const when = calculateWhen(
+    // For max-runtime we only enforce the "scheduled from start time" equality
+    // where startTime is stable. SageMaker notebooks use LastModifiedTime which
+    // can shift during transitions, so we skip the equality check for them.
+    const enforceEquality = resource.type !== 'sagemaker-notebook';
+
+    if (
+      enforceEquality &&
+      resource.tags.maxRuntime &&
+      resource.state === 'running'
+    ) {
+      const expectedWhen = calculateWhen(
         resource.startTime,
         Number(resource.tags.maxRuntime),
       ).toISOString();
-      if (action.when !== when) {
+
+      if (action.when !== expectedWhen) {
         return {
           ...action,
           execute: false,
@@ -850,21 +859,20 @@ export async function processStateAction(
         };
       }
     }
+
     await startExecution(
       stateMachineArn,
       resource,
       nextAction(resource, action),
     );
+
     if (resource.state === 'running') {
       console.log(
-        `${action.resourceType} ${action.resourceId} is running, ${action.action === 'stop' ? 'stopping' : 'rebooting'}...`,
+        `${action.resourceType} ${action.resourceId} is running, ${
+          action.action === 'stop' ? 'stopping' : 'rebooting'
+        }...`,
       );
-      return {
-        ...action,
-        execute: true,
-        reason: 'Checks passed',
-        resource,
-      };
+      return {...action, execute: true, reason: 'Checks passed', resource};
     } else {
       console.log(
         `${action.resourceType} ${action.resourceId} is not running, doing nothing...`,

--- a/handlers/src/scheduler.mts
+++ b/handlers/src/scheduler.mts
@@ -1,6 +1,6 @@
 import * as arnparser from '@aws-sdk/util-arn-parser';
 import * as cron from 'cron-parser';
-import {CronExpression} from 'cron-parser/types';
+import {CronExpression} from 'cron-parser';
 import {
   DescribeInstancesCommand,
   EC2Client,
@@ -834,14 +834,13 @@ export async function processStateAction(
       };
     }
   }
-  if (action.action === 'stop' || action.action === 'reboot') {
-    // For max-runtime we only enforce the "scheduled from start time" equality
-    // where startTime is stable. SageMaker notebooks use LastModifiedTime which
-    // can shift during transitions, so we skip the equality check for them.
-    const enforceEquality = resource.type !== 'sagemaker-notebook';
 
+  if (action.action === 'stop' || action.action === 'reboot') {
+    const isSageMaker = resource.type === 'sagemaker-notebook';
+
+    // Only enforce equality for resources with stable startTime (not SageMaker)
     if (
-      enforceEquality &&
+      !isSageMaker &&
       resource.tags.maxRuntime &&
       resource.state === 'running'
     ) {
@@ -850,7 +849,9 @@ export async function processStateAction(
         Number(resource.tags.maxRuntime),
       ).toISOString();
 
-      if (action.when !== expectedWhen) {
+      if (
+        new Date(action.when).getTime() !== new Date(expectedWhen).getTime()
+      ) {
         return {
           ...action,
           execute: false,
@@ -865,14 +866,16 @@ export async function processStateAction(
       resource,
       nextAction(resource, action),
     );
-
     if (resource.state === 'running') {
       console.log(
-        `${action.resourceType} ${action.resourceId} is running, ${
-          action.action === 'stop' ? 'stopping' : 'rebooting'
-        }...`,
+        `${action.resourceType} ${action.resourceId} is running, ${action.action === 'stop' ? 'stopping' : 'rebooting'}...`,
       );
-      return {...action, execute: true, reason: 'Checks passed', resource};
+      return {
+        ...action,
+        execute: true,
+        reason: 'Checks passed',
+        resource,
+      };
     } else {
       console.log(
         `${action.resourceType} ${action.resourceId} is not running, doing nothing...`,


### PR DESCRIPTION
Add wait InService state for SageMaker notebooks before scheduling  stopping, otherwise it might use Stoptime since its the same field as start in the Sagemaker api called LastModified, unlike Ec2 api which returns starttime